### PR TITLE
Fix the 'index-url' and the 'install' bugs

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,7 +15,7 @@ define pip::install(
     present, installed: {
       $index_url_arg = $index_url ? {
         undef    => '',
-        defaults => "--index_url=${index_url}",
+        default => "--index-url=${index_url}",
       }
 
       if $version != undef {
@@ -29,6 +29,7 @@ define pip::install(
       exec { "install-${package}":
         command => "pip${python_version} install ${index_url_arg} ${package_with_version}",
         unless  => "pip${python_version} freeze | grep '${grep_for}'",
+        require => Exec["install-pip${python_version}"],
       }
     }
 


### PR DESCRIPTION
Hey,

I am sorry but I have pushed an incorrect code.
It should be `index-url` and not `index_url` and `default` instead of `defaults`.
In addition, the `pip::install` can be executed before the `pip${python_version}` resource, so I have put the `require` meta-parameter inside the `exec { "install-${package}"` (correct me if I am wrong).

**Tested** on my Fedora 19 and RHEL 6 VMs.
