### PR TITLE
ensure => absent should require "install-pip"

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -42,6 +42,7 @@ define pip::install(
       exec { "uninstall-${package}":
         command => "pip${python_version} uninstall ${package} -y",
         onlyif  => "pip${python_version} freeze | cut -d= -f1 | egrep '^${package}$'",
+        require => Exec["install-pip${python_version}"],
       }
     }
   }


### PR DESCRIPTION
When trying to uninstall a module, puppet whines that pip2.7 could not be found. Adding this requires, which is the same as the one for "present, installed" solves the issue.